### PR TITLE
change links to vertx-mail-client and vertx-mail-service manual/api pages

### DIFF
--- a/src/site/docs/index.html
+++ b/src/site/docs/index.html
@@ -227,10 +227,10 @@ heading: Documentation
           <h4>SMTP Mail Client</h4>
           <ul class="list-unstyled">
             <li><a href="https://github.com/vert-x3/vertx-mail-client/tree/master/vertx-mail-client">Source</a></li>
-            <li>Java: <a href="{{ site_url }}docs/vertx-mail-service/java/">Manual</a> | <a href="{{ site_url }}docs/apidocs/">API</a></li>
-            <li>JavaScript: <a href="{{ site_url }}docs/vertx-mail-service/js/">Manual</a> | <a href="{{ site_url }}docs/vertx-mail-service/js/jsdoc/">API</a></li>
-            <li>Groovy: <a href="{{ site_url }}docs/vertx-mail-service/groovy/">Manual</a> | <a href="{{ site_url }}docs/vertx-mail-service/groovy/groovydoc/">API</a></li>
-            <li>Ruby: <a href="{{ site_url }}docs/vertx-mail-service/ruby/">Manual</a> | <a href="{{ site_url }}docs/vertx-mail-service/ruby/yardoc/">API</a></li>
+            <li>Java: <a href="{{ site_url }}docs/vertx-mail-client/java/">Manual</a> | <a href="{{ site_url }}docs/apidocs/">API</a></li>
+            <li>JavaScript: <a href="{{ site_url }}docs/vertx-mail-client/js/">Manual</a> | <a href="{{ site_url }}docs/vertx-mail-client/js/jsdoc/">API</a></li>
+            <li>Groovy: <a href="{{ site_url }}docs/vertx-mail-client/groovy/">Manual</a> | <a href="{{ site_url }}docs/vertx-mail-client/groovy/groovydoc/">API</a></li>
+            <li>Ruby: <a href="{{ site_url }}docs/vertx-mail-client/ruby/">Manual</a> | <a href="{{ site_url }}docs/vertx-mail-client/ruby/yardoc/">API</a></li>
           </ul>
         </div>
         <div class="col-md-3">
@@ -238,9 +238,9 @@ heading: Documentation
           <ul class="list-unstyled">
             <li><a href="https://github.com/vert-x3/vertx-mail-client/tree/master/vertx-mail-service">Source</a></li>
             <li>Java: <a href="{{ site_url }}docs/vertx-mail-service/java/">Manual</a> | <a href="{{ site_url }}docs/apidocs/">API</a></li>
-            <li>JavaScript: <a href="{{ site_url }}docs/vertx-mail-client/js/">Manual</a> | <a href="{{ site_url }}docs/vertx-mail-client/js/jsdoc/">API</a></li>
-            <li>Groovy: <a href="{{ site_url }}docs/vertx-mail-client/groovy/">Manual</a> | <a href="{{ site_url }}docs/vertx-mail-client/groovy/groovydoc/">API</a></li>
-            <li>Ruby: <a href="{{ site_url }}docs/vertx-mail-client/ruby/">Manual</a> | <a href="{{ site_url }}docs/vertx-mail-client/ruby/yardoc/">API</a></li>
+            <li>JavaScript: <a href="{{ site_url }}docs/vertx-mail-service/js/">Manual</a> | <a href="{{ site_url }}docs/vertx-mail-service/js/jsdoc/">API</a></li>
+            <li>Groovy: <a href="{{ site_url }}docs/vertx-mail-service/groovy/">Manual</a> | <a href="{{ site_url }}docs/vertx-mail-service/groovy/groovydoc/">API</a></li>
+            <li>Ruby: <a href="{{ site_url }}docs/vertx-mail-service/ruby/">Manual</a> | <a href="{{ site_url }}docs/vertx-mail-service/ruby/yardoc/">API</a></li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
some links in the mail section were flipped between service and client
